### PR TITLE
Fix "or-assign" for return value in netscaler.py

### DIFF
--- a/waf/netscaler.py
+++ b/waf/netscaler.py
@@ -18,7 +18,7 @@ def detect(get_page):
     for vector in WAF_ATTACK_VECTORS:
         _, headers, _ = get_page(get=vector)
         retval = re.search(r"\Aclose", headers.get("Cneonction", "") or headers.get("nnCoection", ""), re.I) is not None
-        retval = re.search(r"\A(ns_af=|citrix_ns_id|NSC_)", headers.get(HTTP_HEADER.SET_COOKIE, ""), re.I) is not None
+        retval |= re.search(r"\A(ns_af=|citrix_ns_id|NSC_)", headers.get(HTTP_HEADER.SET_COOKIE, ""), re.I) is not None
         retval |= re.search(r"\ANS-CACHE", headers.get(HTTP_HEADER.VIA, ""), re.I) is not None
         if retval:
             break


### PR DESCRIPTION
My understanding of this script is that, starting line 20, 3 finds are done and this WAF is positively detected if at least one of them is True.
So an "or-assign" operator should be used in line 21 and 22. In the current code, the result on line 20 is simply discarded by line 21.

For example, the logic is correct in waf/jiasule.py